### PR TITLE
Fix crash in strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@
 
 // Various functions for helping debug WebGL apps.
 
-WebGLDebugUtils = function() {
+var WebGLDebugUtils = function() {
 
 //polyfill window in node
 if (typeof(window) == 'undefined') {


### PR DESCRIPTION
Assigning to a free global crashes in strict mode. This fixes the issue.

https://github.com/uber/luma.gl/issues/345